### PR TITLE
fix: Fixed some of `Chapter` schema field types

### DIFF
--- a/maktab_dl/schemas.py
+++ b/maktab_dl/schemas.py
@@ -289,8 +289,8 @@ class Chapter(BaseModel):
     title: str = ""
     slug: str = ""
     units_count: int = 0
-    total_effort_time: Optional[str] = "0"
-    total_lecture_effort_time: Optional[str] = "0"
+    total_effort_time: Optional[float | str] = "0"
+    total_lecture_effort_time: Optional[float | str] = "0"
     worth: float | str = 0
     desc: str = ""
     locked: bool = False


### PR DESCRIPTION
The chapters effort time fields can be float, currently we sometimes got this validation error: 

```
Error downloading videos: 1 validation error for CourseChaptersModel chapters.5.total_lecture_effort_time
  Input should be a valid string [type=string_type, input_value=0.0, input_type=float]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type
```